### PR TITLE
Serialize modern Vision OCR and harden subtitle image creation

### DIFF
--- a/Sources/macSubtitleOCR/Subtitles/Subtitle.swift
+++ b/Sources/macSubtitleOCR/Subtitles/Subtitle.swift
@@ -9,7 +9,9 @@
 import CoreGraphics
 import Foundation
 
-class Subtitle: @unchecked Sendable {
+// Subtitle instances are no longer shared across OCR tasks; they are only moved
+// between isolated contexts when collecting final results.
+final class Subtitle: @unchecked Sendable {
     var index: Int
     var text: String?
     var startTimestamp: TimeInterval?
@@ -47,14 +49,84 @@ class Subtitle: @unchecked Sendable {
 
     // MARK: - Functions
 
+    func makeImageSource() -> SubtitleImageSource? {
+        guard
+            let imageWidth,
+            let imageData,
+            let imagePalette,
+            let numberOfColors,
+            imageWidth > 0
+        else {
+            return nil
+        }
+
+        let availableHeight = imageData.count / imageWidth
+        let resolvedHeight = min(imageHeight ?? availableHeight, availableHeight)
+        guard resolvedHeight > 0 else {
+            return nil
+        }
+
+        return SubtitleImageSource(width: imageWidth,
+                                   height: resolvedHeight,
+                                   imageData: imageData,
+                                   imagePalette: imagePalette,
+                                   numberOfColors: numberOfColors)
+    }
+}
+
+struct SubtitleImageSource: Sendable {
+    let width: Int
+    let height: Int
+    let imageData: Data
+    let imagePalette: [UInt8]
+    let numberOfColors: Int
+
+    // MARK: - Methods
+
+    // Converts the image data to RGBA format using the palette
+    private func imageDataToRGBA() -> Data {
+        let bytesPerPixel = 4
+        let pixelCount = width * height
+        var rgbaData = Data(capacity: pixelCount * bytesPerPixel)
+
+        for index in 0 ..< pixelCount {
+            let colorIndex = Int(imageData[index])
+            let paletteOffset = colorIndex * bytesPerPixel
+            guard
+                colorIndex >= 0,
+                colorIndex < numberOfColors,
+                paletteOffset + 3 < imagePalette.count
+            else {
+                rgbaData.append(contentsOf: [255, 255, 255, 255])
+                continue
+            }
+
+            rgbaData.append(contentsOf: [
+                imagePalette[paletteOffset],
+                imagePalette[paletteOffset + 1],
+                imagePalette[paletteOffset + 2],
+                imagePalette[paletteOffset + 3]
+            ])
+        }
+
+        return rgbaData
+    }
+
     // Converts the RGBA data to a CGImage
     func createImage(_ invert: Bool) -> CGImage? {
         var rgbaData = imageDataToRGBA()
+        guard rgbaData.count == width * height * 4 else {
+            return nil
+        }
 
-        var minX = imageWidth!, maxX = 0, minY = imageHeight!, maxY = 0
-        for y in 0 ..< imageHeight! {
-            for x in 0 ..< imageWidth! {
-                let pixelIndex = (y * imageWidth! + x) * 4
+        var minX = width
+        var maxX = -1
+        var minY = height
+        var maxY = -1
+
+        for y in 0 ..< height {
+            for x in 0 ..< width {
+                let pixelIndex = (y * width + x) * 4
                 let alpha = rgbaData[pixelIndex + 3]
                 if alpha > 0 {
                     minX = min(minX, x)
@@ -76,17 +148,21 @@ class Subtitle: @unchecked Sendable {
             }
         }
 
+        guard minX < width, maxX >= 0, minY < height, maxY >= 0 else {
+            return nil
+        }
+
         guard let provider = CGDataProvider(data: rgbaData as CFData) else { return nil }
         let bitmapInfo = CGBitmapInfo.byteOrder32Big
             .union(CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue))
         let colorSpace = CGColorSpaceCreateDeviceRGB()
 
         let image = CGImage(
-            width: imageWidth!,
-            height: imageHeight!,
+            width: width,
+            height: height,
             bitsPerComponent: 8,
             bitsPerPixel: 32,
-            bytesPerRow: imageWidth! * 4,
+            bytesPerRow: width * 4,
             space: colorSpace,
             bitmapInfo: bitmapInfo,
             provider: provider,
@@ -94,40 +170,7 @@ class Subtitle: @unchecked Sendable {
             shouldInterpolate: false,
             intent: .defaultIntent)
 
-        if minX == imageWidth! || maxX == 0 || minY == imageHeight! || maxY == 0 {
-            return nil
-        }
         let croppedRect = CGRect(x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1)
         return image?.cropping(to: croppedRect)
-    }
-
-    // MARK: - Methods
-
-    // Converts the image data to RGBA format using the palette
-    private func imageDataToRGBA() -> Data {
-        let bytesPerPixel = 4
-        imageHeight = imageData!.count / imageWidth!
-        var rgbaData = Data(capacity: imageWidth! * imageHeight! * bytesPerPixel)
-
-        for y in 0 ..< imageHeight! {
-            for x in 0 ..< imageWidth! {
-                let index = Int(y) * imageWidth! + Int(x)
-                let colorIndex = Int(imageData![index])
-
-                guard colorIndex < numberOfColors! else {
-                    continue
-                }
-
-                let paletteOffset = colorIndex * bytesPerPixel
-                rgbaData.append(contentsOf: [
-                    imagePalette![paletteOffset],
-                    imagePalette![paletteOffset + 1],
-                    imagePalette![paletteOffset + 2],
-                    imagePalette![paletteOffset + 3]
-                ])
-            }
-        }
-
-        return rgbaData
     }
 }

--- a/Sources/macSubtitleOCR/Subtitles/SubtitleProcessor.swift
+++ b/Sources/macSubtitleOCR/Subtitles/SubtitleProcessor.swift
@@ -11,6 +11,24 @@ import Foundation
 import UniformTypeIdentifiers
 import Vision
 
+private struct OCRSubtitleTaskInput: Sendable {
+    let index: Int
+    let startTimestamp: TimeInterval?
+    let endTimestamp: TimeInterval?
+    let imageSource: SubtitleImageSource?
+
+    init(_ subtitle: Subtitle) {
+        index = subtitle.index
+        startTimestamp = subtitle.startTimestamp
+        endTimestamp = subtitle.endTimestamp
+        imageSource = subtitle.makeImageSource()
+    }
+
+    func makeSubtitle(text: String) -> Subtitle {
+        Subtitle(index: index, text: text, startTimestamp: startTimestamp, endTimestamp: endTimestamp)
+    }
+}
+
 struct SubtitleProcessor {
     private let subtitles: [Subtitle]
     private let trackNumber: Int
@@ -44,21 +62,24 @@ struct SubtitleProcessor {
 
     func process() async throws -> macSubtitleOCRResult {
         let accumulator = SubtitleAccumulator()
-        let semaphore = AsyncSemaphore(limit: maxConcurrentTasks) // Limit concurrent tasks
+        let taskSemaphore = AsyncSemaphore(limit: maxConcurrentTasks)
+        let textRecognitionSemaphore = AsyncSemaphore(limit: shouldSerializeModernTextRecognition ? 1 : maxConcurrentTasks)
+        let taskInputs = subtitles.map(OCRSubtitleTaskInput.init)
 
         try await withThrowingDiscardingTaskGroup { group in
-            for subtitle in subtitles {
+            for taskInput in taskInputs {
                 group.addTask {
-                    // Wait for permission to start the task
-                    await semaphore.wait()
-                    let subIndex = subtitle.index
+                    await taskSemaphore.wait()
+                    defer { Task { await taskSemaphore.signal() } }
 
-                    guard !shouldSkip(subtitle), let subImage = subtitle.createImage(invert) else {
+                    let subIndex = taskInput.index
+
+                    guard !shouldSkip(taskInput), let imageSource = taskInput.imageSource,
+                          let subImage = imageSource.createImage(invert) else {
                         print(
                             "Found invalid image for track: \(trackNumber), index: \(subIndex), creating an empty placeholder!")
-                        subtitle.text = ""
-                        await accumulator.append(subtitle, SubtitleJSONResult(index: subIndex, lines: [], text: ""))
-                        await semaphore.signal()
+                        await accumulator.append(taskInput.makeSubtitle(text: ""),
+                                                 SubtitleJSONResult(index: subIndex, lines: [], text: ""))
                         return
                     }
 
@@ -73,23 +94,22 @@ struct SubtitleProcessor {
                         }
                     }
 
-                    let (subtitleText, subtitleLines) = await recognizeText(from: subImage)
+                    let (subtitleText, subtitleLines) = await recognizeText(from: subImage,
+                                                                            textRecognitionSemaphore: textRecognitionSemaphore)
+                    let correctedText: String
                     if language.contains("en"), !disableICorrection {
                         let pattern = #"\bl\b"# // Replace l with I when it's a single character
-                        subtitle.text = subtitleText.replacingOccurrences(
+                        correctedText = subtitleText.replacingOccurrences(
                             of: pattern,
                             with: "I",
                             options: .regularExpression)
                     } else {
-                        subtitle.text = subtitleText
+                        correctedText = subtitleText
                     }
-                    subtitle.imageData = nil // Clear the image data to save memory
 
-                    let jsonOut = SubtitleJSONResult(index: subIndex, lines: subtitleLines, text: subtitleText)
+                    let jsonOut = SubtitleJSONResult(index: subIndex, lines: subtitleLines, text: correctedText)
 
-                    // Safely append to the arrays using the actor
-                    await accumulator.append(subtitle, jsonOut)
-                    await semaphore.signal()
+                    await accumulator.append(taskInput.makeSubtitle(text: correctedText), jsonOut)
                 }
             }
         }
@@ -97,17 +117,37 @@ struct SubtitleProcessor {
         return await macSubtitleOCRResult(trackNumber: trackNumber, srt: accumulator.subtitles, json: accumulator.json)
     }
 
-    private func shouldSkip(_ subtitle: Subtitle) -> Bool {
-        subtitle.imageWidth == 0 || subtitle.imageHeight == 0
+    private var shouldSerializeModernTextRecognition: Bool {
+        guard !forceOldAPI else {
+            return false
+        }
+        if #available(macOS 15.0, *) {
+            return true
+        }
+        return false
     }
 
-    private func recognizeText(from image: CGImage) async -> (String, [SubtitleLine]) {
+    private func shouldSkip(_ taskInput: OCRSubtitleTaskInput) -> Bool {
+        guard let imageSource = taskInput.imageSource else {
+            return true
+        }
+        return imageSource.width == 0 || imageSource.height == 0
+    }
+
+    private func recognizeText(from image: CGImage, textRecognitionSemaphore: AsyncSemaphore) async -> (String, [SubtitleLine]) {
         var text = ""
         var lines: [SubtitleLine] = []
 
         if !forceOldAPI, #available(macOS 15.0, *) {
-            let request = createRecognizeTextRequest()
-            let observations = try? await request.perform(on: image) as [RecognizedTextObservation]
+            await textRecognitionSemaphore.wait()
+            let observations: [RecognizedTextObservation]?
+            do {
+                let request = createRecognizeTextRequest()
+                observations = try await request.perform(on: image) as [RecognizedTextObservation]
+            } catch {
+                observations = nil
+            }
+            await textRecognitionSemaphore.signal()
             let size = CGSize(width: image.width, height: image.height)
             processRecognizedText(observations, &text, &lines, size)
         } else {


### PR DESCRIPTION
I was having trouble with segvs about 20% of the time I tried to generate subtitles.

Crashes such as this:
```
💣 Program crashed: Bad pointer dereference at 0x000024b156cbc148

Platform: arm64 macOS 26.4 (25E246)

Thread 3 crashed:

  0 0x000000018a0d8014 objc_release + 16 in libobjc.A.dylib
  1 0x00000001c1310ac0 <unknown> + 76 in TextRecognition
  2 0x00000001c1310b34 <unknown> + 16 in TextRecognition
  3 0x000000019dbcacb0 _swift_release_dealloc + 64 in libswiftCore.dylib
  4 0x000000019dc2dae4 bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1>>::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 168 in libswiftCore.dylib
  5 0x00000001c12eb0a0 <unknown> + 84 in TextRecognition
  6 0x00000001c12eb10c <unknown> + 16 in TextRecognition
  7 0x000000019dbcacb0 _swift_release_dealloc + 64 in libswiftCore.dylib
  8 0x000000019dc2dc6c bool swift::RefCounts<swift::SideTableRefCountBits>::doDecrementSlow<(swift::PerformDeinit)1>(swift::SideTableRefCountBits, unsigned int) + 176 in libswiftCore.dylib
  9 0x00000001c132b4c4 <unknown> + 32 in TextRecognition
 10 0x000000019dbcacb0 _swift_release_dealloc + 64 in libswiftCore.dylib
 11 0x000000019dc2dae4 bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1>>::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 168 in libswiftCore.dylib
 12 0x00000001a2dfda90 <unknown> + 452 in Vision
 13 0x00000001a2de6a30 <unknown> in Vision
 14 0x00000001a2decf94 <unknown> in Vision
 15 0x00000001a2de5414 <unknown> in Vision
 16 0x00000001a2dec938 <unknown> in Vision
 17 0x00000001a2de4788 <unknown> in Vision
 18 0x00000001a2e332bc <unknown> in Vision
 19 0x00000001a2db3864 <unknown> in Vision
 20 0x00000001a2dc18a4 <unknown> in Vision
 21 0x00000001a2db3864 <unknown> in Vision
```

I don't know any Swift so I asked Codex 5.4 to look into the problem and it came up with this fix. Feel free to ignore it as junk but so far I haven't had any crashes... If I start getting crashes again I'll report back here so you can completely ignore it.

The fixes are:

1. Avoid sharing mutable Subtitle instances across OCR tasks by snapshotting task inputs before concurrent processing. Serialize macOS 15+ TextRecognition requests to reduce framework-related crashes, while keeping the rest of the pipeline concurrent.
2. Also harden RGBA image generation to always produce a full pixel buffer and gracefully handle invalid palette indices instead of creating malformed images.